### PR TITLE
Add --specs=nosys.specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ CFLAGS+=	-mcpu=cortex-m4
 CFLAGS+=	-mlittle-endian -mthumb -mthumb-interwork
 CFLAGS+=	-mfloat-abi=soft -mfpu=fpv4-sp-d16
 CFLAGS+=	-ffreestanding
+CFLAGS+=	--specs=nosys.specs
 
 # Preprocessor flags.
 CPPFLAGS+=	-DSTM32F407xx


### PR DESCRIPTION
Thanks for example makefile.
I had to add one line to compiler since I got `_exit` errors.
```
/usr/bin/../lib/gcc/arm-none-eabi/7.3.1/../../../../arm-none-eabi/lib/libg.a(lib_a-exit.o): In function `exit':
exit.c:(.text.exit+0x2c): undefined reference to `_exit'
collect2: error: ld returned 1 exit status
Makefile:54: recipe for target 'gpio.elf' failed
make: *** [gpio.elf] Error 1
```
Fix by:
https://stackoverflow.com/questions/19419782/exit-c-text0x18-undefined-reference-to-exit-when-using-arm-none-eabi-gcc


My gcc version
```
hub@hpnix:~/Desktop/dev/STM32/stm32cubef4_example$ arm-none-eabi-gcc --version
arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2018-q3-update) 7.3.1 20180622 (release) [ARM/embedded-7-branch revision 261907]
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```